### PR TITLE
Behavioral fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,5 @@
 # vim-tabbar
 
-## Preface
-
-This is a fork of [drmingdrmer/vim-tabbar](https://github.com/drmingdrmer/vim-tabbar), which was the closest plugin to the functionality I wanted out of my tab bar.
-
-There are exactly two differences between this fork and the original:
-
-1. `"[No Name]" -> " [No Name] "`, to fix the spacing.
-2. There is now a middle-man function `TabLabel` which returns exactly what `BufLabel` returns, plus a `+` if the file is modified.
-
-TL;DR - I made it behave more like the *built-in* tabline.
-
-So if you're using drmingdrmer's buftabline and find yourself hurting for that little `+` to let you know the buffer is modified, this fork is for you.
-
-## Original Readme
-
 Simple, stupid and fast tab-bar for VIM.
 
 Names of opened buffer are shortened and shows on the top row of window.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # vim-tabbar
 
+## Preface
+
+This is a fork of [drmingdrmer/vim-tabbar](https://github.com/drmingdrmer/vim-tabbar), which was the closest plugin to the functionality I wanted out of my tab bar.
+
+There are exactly two differences between this fork and the original:
+
+1. `"[No Name]" -> " [No Name] "`, to fix the spacing.
+2. There is now a middle-man function `TabLabel` which returns exactly what `BufLabel` returns, plus a `+` if the file is modified.
+
+TL;DR - I made it behave more like the *built-in* tabline.
+
+So if you're using drmingdrmer's buftabline and find yourself hurting for that little `+` to let you know the buffer is modified, this fork is for you.
+
+## Original Readme
+
 Simple, stupid and fast tab-bar for VIM.
 
 Names of opened buffer are shortened and shows on the top row of window.

--- a/autoload/vimtabbar.vim
+++ b/autoload/vimtabbar.vim
@@ -13,7 +13,7 @@ fun! vimtabbar#Build() "{{{
             continue
         endif
 
-        let name = s:BufLabel(i)
+        let name = s:TabLabel(i)
 
         let synname = 'TabLineFill'
         if cur == i
@@ -51,6 +51,7 @@ fun! vimtabbar#Build() "{{{
     let rst = ''
     for elt in names
         let rst .= '%#' . elt['syn'] . '#' . elt['text'] . '%0*'
+
     endfor
     return rst
 endfunction "}}}
@@ -67,10 +68,21 @@ fun! s:IsVisible(i) "{{{
     return 1
 endfunction "}}}
 
+fun! s:TabLabel(i) "{{{
+    let mod = getbufvar(a:i, "&mod")
+    let text = ""
+
+    if mod == 1
+        let text = "+"
+    endif
+
+    return text . s:BufLabel(a:i)
+endfunction"}}}
+
 fun! s:BufLabel(i) "{{{
     let path = bufname(a:i)
     if path == ""
-        return '[No Name]'
+        return ' [No Name] '
     endif
 
     let path = s:PathForHuman(path)

--- a/autoload/vimtabbar.vim
+++ b/autoload/vimtabbar.vim
@@ -73,7 +73,7 @@ fun! s:TabLabel(i) "{{{
     let text = ""
 
     if mod == 1
-        let text = "+"
+        let text = " +"
     endif
 
     return text . s:BufLabel(a:i)


### PR DESCRIPTION
This fork makes two changes:

1. `"[No Name]"` -> `" [No Name] "` - aesthetics
2. `~/somefile` -> `+ ~/somefile` - information

In other words, it brings the behavior closer to the built-in tab bar.